### PR TITLE
SideNavbar Typo Fix

### DIFF
--- a/src/components/SideNavbar.jsx
+++ b/src/components/SideNavbar.jsx
@@ -31,7 +31,7 @@ export default function DefaultSidebar() {
         <List>
           <ListItem>Stack</ListItem>
           <ListItem>Queue</ListItem>
-          <ListItem>Linekd List</ListItem>
+          <ListItem>Linked List</ListItem>
           <ListItem>Tree</ListItem>
           <ListItem>Graph</ListItem>
         </List>


### PR DESCRIPTION
One of the list items in the `SideNavbar.jsx` file has a typo!

#### Change Description
| Previous | Current |
| --- | ----------- |
| `Linekd List` | `Linked List` |

**Fixes**: #24 